### PR TITLE
Adding Intl metadata localization_priority to source markdown topics

### DIFF
--- a/project-xml-data-interchange/accrueat-element.md
+++ b/project-xml-data-interchange/accrueat-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AccrueAt element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AccrueAt Element

--- a/project-xml-data-interchange/activedirectoryguid-element.md
+++ b/project-xml-data-interchange/activedirectoryguid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActiveDirectoryGUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActiveDirectoryGUID Element

--- a/project-xml-data-interchange/actualcost-element.md
+++ b/project-xml-data-interchange/actualcost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualCost Element

--- a/project-xml-data-interchange/actualduration-element.md
+++ b/project-xml-data-interchange/actualduration-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualDuration element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualDuration Element

--- a/project-xml-data-interchange/actualfinish-element.md
+++ b/project-xml-data-interchange/actualfinish-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualFinish element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualFinish Element

--- a/project-xml-data-interchange/actualovertimecost-element.md
+++ b/project-xml-data-interchange/actualovertimecost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualOvertimeCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualOvertimeCost Element

--- a/project-xml-data-interchange/actualovertimework-element.md
+++ b/project-xml-data-interchange/actualovertimework-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualOvertimeWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualOvertimeWork Element

--- a/project-xml-data-interchange/actualovertimeworkprotected-element.md
+++ b/project-xml-data-interchange/actualovertimeworkprotected-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualOvertimeWorkProtected element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualOvertimeWorkProtected Element

--- a/project-xml-data-interchange/actualsinsync-element.md
+++ b/project-xml-data-interchange/actualsinsync-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualsInSync element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualsInSync Element

--- a/project-xml-data-interchange/actualstart-element.md
+++ b/project-xml-data-interchange/actualstart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualStart Element

--- a/project-xml-data-interchange/actualwork-element.md
+++ b/project-xml-data-interchange/actualwork-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualWork Element

--- a/project-xml-data-interchange/actualworkprotected-element.md
+++ b/project-xml-data-interchange/actualworkprotected-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ActualWorkProtected element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ActualWorkProtected Element

--- a/project-xml-data-interchange/acwp-element.md
+++ b/project-xml-data-interchange/acwp-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ACWP element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ACWP Element

--- a/project-xml-data-interchange/adminproject-element.md
+++ b/project-xml-data-interchange/adminproject-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AdminProject element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AdminProject Element

--- a/project-xml-data-interchange/agilemode-element.md
+++ b/project-xml-data-interchange/agilemode-element.md
@@ -2,6 +2,7 @@
 title: AgileMode Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # AgileMode Element

--- a/project-xml-data-interchange/alias-element.md
+++ b/project-xml-data-interchange/alias-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Alias Element

--- a/project-xml-data-interchange/alllevelsrequired-element.md
+++ b/project-xml-data-interchange/alllevelsrequired-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AllLevelsRequired element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AllLevelsRequired Element

--- a/project-xml-data-interchange/alphabetical-list-of-elements-and-types.md
+++ b/project-xml-data-interchange/alphabetical-list-of-elements-and-types.md
@@ -11,6 +11,7 @@ f1_keywords:
 - XML in Project
 - Project 2007 XML
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Alphabetical List of Elements and Types

--- a/project-xml-data-interchange/appendnewvalues-element.md
+++ b/project-xml-data-interchange/appendnewvalues-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AppendNewValues element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AppendNewValues Element

--- a/project-xml-data-interchange/assignment-element.md
+++ b/project-xml-data-interchange/assignment-element.md
@@ -2,6 +2,7 @@
 title: Assignment Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Assignment Element

--- a/project-xml-data-interchange/assignment-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/assignment-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Assignment Elements and XML Structure

--- a/project-xml-data-interchange/assignments-element.md
+++ b/project-xml-data-interchange/assignments-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Assignments element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Assignments Element

--- a/project-xml-data-interchange/assnowner-element.md
+++ b/project-xml-data-interchange/assnowner-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AssnOwner Element

--- a/project-xml-data-interchange/assnownerguid-element.md
+++ b/project-xml-data-interchange/assnownerguid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AssnOwnerGuid Element

--- a/project-xml-data-interchange/author-element.md
+++ b/project-xml-data-interchange/author-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Author element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Author Element

--- a/project-xml-data-interchange/autoaddnewresourcesandtasks-element.md
+++ b/project-xml-data-interchange/autoaddnewresourcesandtasks-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AutoAddNewResourcesAndTasks element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AutoAddNewResourcesAndTasks Element

--- a/project-xml-data-interchange/autolink-element.md
+++ b/project-xml-data-interchange/autolink-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Autolink element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Autolink Element

--- a/project-xml-data-interchange/autorolldown-element.md
+++ b/project-xml-data-interchange/autorolldown-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AutoRollDown Element

--- a/project-xml-data-interchange/availabilityperiod-element.md
+++ b/project-xml-data-interchange/availabilityperiod-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AvailabilityPeriod element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AvailabilityPeriod Element

--- a/project-xml-data-interchange/availabilityperiods-element.md
+++ b/project-xml-data-interchange/availabilityperiods-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AvailabilityPeriods element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AvailabilityPeriods Element

--- a/project-xml-data-interchange/availablefrom-element.md
+++ b/project-xml-data-interchange/availablefrom-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AvailableFrom element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AvailableFrom Element

--- a/project-xml-data-interchange/availableto-element.md
+++ b/project-xml-data-interchange/availableto-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AvailableTo element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AvailableTo Element

--- a/project-xml-data-interchange/availableunits-element.md
+++ b/project-xml-data-interchange/availableunits-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - AvailableUnits element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # AvailableUnits Element

--- a/project-xml-data-interchange/b408000-b417fff-elements.md
+++ b/project-xml-data-interchange/b408000-b417fff-elements.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # b408000 - b417fff Elements

--- a/project-xml-data-interchange/b608000-b617fff-elements.md
+++ b/project-xml-data-interchange/b608000-b617fff-elements.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # b608000 - b617fff Elements

--- a/project-xml-data-interchange/basecalendaruid-element.md
+++ b/project-xml-data-interchange/basecalendaruid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BaseCalendarUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BaseCalendarUID Element

--- a/project-xml-data-interchange/baseline-element.md
+++ b/project-xml-data-interchange/baseline-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Baseline element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Baseline Element

--- a/project-xml-data-interchange/baselineforearnedvalue-element.md
+++ b/project-xml-data-interchange/baselineforearnedvalue-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BaselineForEarnedValue element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BaselineForEarnedValue Element

--- a/project-xml-data-interchange/bcwp-element.md
+++ b/project-xml-data-interchange/bcwp-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BCWP element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BCWP Element

--- a/project-xml-data-interchange/bcws-element.md
+++ b/project-xml-data-interchange/bcws-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BCWS element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BCWS Element

--- a/project-xml-data-interchange/boardcolumn-element.md
+++ b/project-xml-data-interchange/boardcolumn-element.md
@@ -2,6 +2,7 @@
 title: BoardColumn Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # BoardColumn Element

--- a/project-xml-data-interchange/boardcolumns-element.md
+++ b/project-xml-data-interchange/boardcolumns-element.md
@@ -2,6 +2,7 @@
 title: BoardColumns Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # BoardColumns Element

--- a/project-xml-data-interchange/boardcolumnuid-element.md
+++ b/project-xml-data-interchange/boardcolumnuid-element.md
@@ -2,6 +2,7 @@
 title: BoardColumnUID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # BoardColumnUID Element

--- a/project-xml-data-interchange/boardstatuscolumnorderingid-element.md
+++ b/project-xml-data-interchange/boardstatuscolumnorderingid-element.md
@@ -2,6 +2,7 @@
 title: BoardStatusColumnOrderingID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # BoardStatusColumnOrderingID Element

--- a/project-xml-data-interchange/bookingtype-element.md
+++ b/project-xml-data-interchange/bookingtype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BookingType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BookingType Element

--- a/project-xml-data-interchange/budgetcost-element.md
+++ b/project-xml-data-interchange/budgetcost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BudgetCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BudgetCost Element

--- a/project-xml-data-interchange/budgetwork-element.md
+++ b/project-xml-data-interchange/budgetwork-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - BudgetWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # BudgetWork Element

--- a/project-xml-data-interchange/buildnumber-element.md
+++ b/project-xml-data-interchange/buildnumber-element.md
@@ -3,6 +3,7 @@ title: BuildNumber Element
 ms.date: 03/14/2018
 mtps_version: v=office.14
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Build Number Element

--- a/project-xml-data-interchange/c408000-c417fff-elements.md
+++ b/project-xml-data-interchange/c408000-c417fff-elements.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # c408000 - c417fff Elements

--- a/project-xml-data-interchange/calculationtype-element.md
+++ b/project-xml-data-interchange/calculationtype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CalculationType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CalculationType Element

--- a/project-xml-data-interchange/calendar-element.md
+++ b/project-xml-data-interchange/calendar-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Calendar Element

--- a/project-xml-data-interchange/calendar-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/calendar-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Calendar Elements and XML Structure

--- a/project-xml-data-interchange/calendars-element.md
+++ b/project-xml-data-interchange/calendars-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Calendars element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Calendars Element

--- a/project-xml-data-interchange/calendaruid-element.md
+++ b/project-xml-data-interchange/calendaruid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CalendarUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CalendarUID Element

--- a/project-xml-data-interchange/canlevel-element.md
+++ b/project-xml-data-interchange/canlevel-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CanLevel element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CanLevel Element

--- a/project-xml-data-interchange/category-element.md
+++ b/project-xml-data-interchange/category-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Category element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Category Element

--- a/project-xml-data-interchange/cftype-element.md
+++ b/project-xml-data-interchange/cftype-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CFType Element

--- a/project-xml-data-interchange/changes-in-the-project-2007-xml-data-interchange-schema.md
+++ b/project-xml-data-interchange/changes-in-the-project-2007-xml-data-interchange-schema.md
@@ -14,6 +14,7 @@ f1_keywords:
 - Project 2007, XML
 - Project XML schema changes
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Changes in the Project 2007 XML Data Interchange Schema

--- a/project-xml-data-interchange/code-element.md
+++ b/project-xml-data-interchange/code-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Code element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Code Element

--- a/project-xml-data-interchange/columnname-element.md
+++ b/project-xml-data-interchange/columnname-element.md
@@ -2,6 +2,7 @@
 title: ColumnName Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ColumnName Element

--- a/project-xml-data-interchange/columnnames-element.md
+++ b/project-xml-data-interchange/columnnames-element.md
@@ -2,6 +2,7 @@
 title: ColumnNames Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ColumnNames Element

--- a/project-xml-data-interchange/commitmentfinish-element.md
+++ b/project-xml-data-interchange/commitmentfinish-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CommitmentFinish element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CommitmentFinish Element

--- a/project-xml-data-interchange/commitmentstart-element.md
+++ b/project-xml-data-interchange/commitmentstart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CommitmentStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CommitmentStart Element

--- a/project-xml-data-interchange/commitmenttype-element.md
+++ b/project-xml-data-interchange/commitmenttype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CommitmentType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CommitmentType Element

--- a/project-xml-data-interchange/company-element.md
+++ b/project-xml-data-interchange/company-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Company element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Company Element

--- a/project-xml-data-interchange/confirmed-element.md
+++ b/project-xml-data-interchange/confirmed-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Confirmed element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Confirmed Element

--- a/project-xml-data-interchange/constraintdate-element.md
+++ b/project-xml-data-interchange/constraintdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ConstraintDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ConstraintDate Element

--- a/project-xml-data-interchange/constrainttype-element.md
+++ b/project-xml-data-interchange/constrainttype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ConstraintType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ConstraintType Element

--- a/project-xml-data-interchange/contact-element.md
+++ b/project-xml-data-interchange/contact-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Contact element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Contact Element

--- a/project-xml-data-interchange/cost-element.md
+++ b/project-xml-data-interchange/cost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Cost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Cost Element

--- a/project-xml-data-interchange/costperuse-element.md
+++ b/project-xml-data-interchange/costperuse-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CostPerUse element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CostPerUse Element

--- a/project-xml-data-interchange/costratetable-element.md
+++ b/project-xml-data-interchange/costratetable-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CostRateTable element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CostRateTable Element

--- a/project-xml-data-interchange/costvariance-element.md
+++ b/project-xml-data-interchange/costvariance-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CostVariance element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CostVariance Element

--- a/project-xml-data-interchange/createdate-element.md
+++ b/project-xml-data-interchange/createdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CreateDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CreateDate Element

--- a/project-xml-data-interchange/creationdate-element.md
+++ b/project-xml-data-interchange/creationdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CreationDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CreationDate Element

--- a/project-xml-data-interchange/critical-element.md
+++ b/project-xml-data-interchange/critical-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Critical element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Critical Element

--- a/project-xml-data-interchange/criticalslacklimit-element.md
+++ b/project-xml-data-interchange/criticalslacklimit-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CriticalSlackLimit element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CriticalSlackLimit Element

--- a/project-xml-data-interchange/crossproject-element.md
+++ b/project-xml-data-interchange/crossproject-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CrossProject element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CrossProject Element

--- a/project-xml-data-interchange/crossprojectname-element.md
+++ b/project-xml-data-interchange/crossprojectname-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CrossProjectName element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CrossProjectName Element

--- a/project-xml-data-interchange/currencycode-element.md
+++ b/project-xml-data-interchange/currencycode-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CurrencyCode Element

--- a/project-xml-data-interchange/currencydigits-element.md
+++ b/project-xml-data-interchange/currencydigits-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CurrencyDigits element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CurrencyDigits Element

--- a/project-xml-data-interchange/currencysymbol-element.md
+++ b/project-xml-data-interchange/currencysymbol-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CurrencySymbol element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CurrencySymbol Element

--- a/project-xml-data-interchange/currencysymbolposition-element.md
+++ b/project-xml-data-interchange/currencysymbolposition-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CurrencySymbolPosition element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CurrencySymbolPosition Element

--- a/project-xml-data-interchange/currentdate-element.md
+++ b/project-xml-data-interchange/currentdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CurrentDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CurrentDate Element

--- a/project-xml-data-interchange/custom-field-data-in-xml.md
+++ b/project-xml-data-interchange/custom-field-data-in-xml.md
@@ -14,6 +14,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Custom Field Data in XML

--- a/project-xml-data-interchange/cv-element.md
+++ b/project-xml-data-interchange/cv-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - CV element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # CV Element

--- a/project-xml-data-interchange/datalink-element.md
+++ b/project-xml-data-interchange/datalink-element.md
@@ -2,6 +2,7 @@
 title: DataLink Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2013 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DataLink Element

--- a/project-xml-data-interchange/datalinks-element.md
+++ b/project-xml-data-interchange/datalinks-element.md
@@ -2,6 +2,7 @@
 title: DataLinks Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2013 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DataLinks Element

--- a/project-xml-data-interchange/daysofweek-element.md
+++ b/project-xml-data-interchange/daysofweek-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DaysOfWeek Element

--- a/project-xml-data-interchange/dayspermonth-element.md
+++ b/project-xml-data-interchange/dayspermonth-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DaysPerMonth element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DaysPerMonth Element

--- a/project-xml-data-interchange/daytype-element.md
+++ b/project-xml-data-interchange/daytype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DayType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DayType Element

--- a/project-xml-data-interchange/dayworking-element-calendar.md
+++ b/project-xml-data-interchange/dayworking-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DayWorking element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DayWorking Element (Calendar)

--- a/project-xml-data-interchange/deadline-element.md
+++ b/project-xml-data-interchange/deadline-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Deadline element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Deadline Element

--- a/project-xml-data-interchange/default-element-extendedattribute.md
+++ b/project-xml-data-interchange/default-element-extendedattribute.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Default element (ExtendedAttribute)
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Default Element (ExtendedAttribute)

--- a/project-xml-data-interchange/defaultfinishtime-element.md
+++ b/project-xml-data-interchange/defaultfinishtime-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultFinishTime element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultFinishTime Element

--- a/project-xml-data-interchange/defaultfixedcostaccrual-element.md
+++ b/project-xml-data-interchange/defaultfixedcostaccrual-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultFixedCostAccrual element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultFixedCostAccrual Element

--- a/project-xml-data-interchange/defaultguid-element.md
+++ b/project-xml-data-interchange/defaultguid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultGuid Element

--- a/project-xml-data-interchange/defaultovertimerate-element.md
+++ b/project-xml-data-interchange/defaultovertimerate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultOvertimeRate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultOvertimeRate Element

--- a/project-xml-data-interchange/defaultstandardrate-element.md
+++ b/project-xml-data-interchange/defaultstandardrate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultStandardRate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultStandardRate Element

--- a/project-xml-data-interchange/defaultstarttime-element.md
+++ b/project-xml-data-interchange/defaultstarttime-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultStartTime element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultStartTime Element

--- a/project-xml-data-interchange/defaulttaskevmethod-element.md
+++ b/project-xml-data-interchange/defaulttaskevmethod-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultTaskEVMethod element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultTaskEVMethod Element

--- a/project-xml-data-interchange/defaulttasktype-element.md
+++ b/project-xml-data-interchange/defaulttasktype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - DefaultTaskType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DefaultTaskType Element

--- a/project-xml-data-interchange/delay-element.md
+++ b/project-xml-data-interchange/delay-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Delay element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Delay Element

--- a/project-xml-data-interchange/description-element.md
+++ b/project-xml-data-interchange/description-element.md
@@ -2,6 +2,7 @@
 title: Description Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Description Element

--- a/project-xml-data-interchange/drawing-element.md
+++ b/project-xml-data-interchange/drawing-element.md
@@ -2,6 +2,7 @@
 title: Drawing Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2013 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Drawing Element

--- a/project-xml-data-interchange/drawings-element.md
+++ b/project-xml-data-interchange/drawings-element.md
@@ -2,6 +2,7 @@
 title: Drawings Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2013 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Drawings Element

--- a/project-xml-data-interchange/duration-element.md
+++ b/project-xml-data-interchange/duration-element.md
@@ -2,6 +2,7 @@
 title: Duration Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Duration Element

--- a/project-xml-data-interchange/durationformat-element.md
+++ b/project-xml-data-interchange/durationformat-element.md
@@ -2,6 +2,7 @@
 title: DurationFormat Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # DurationFormat Element

--- a/project-xml-data-interchange/durationunits-element.md
+++ b/project-xml-data-interchange/durationunits-element.md
@@ -2,6 +2,7 @@
 title: DurationUnits Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # DurationUnits Element

--- a/project-xml-data-interchange/earlyfinish-element.md
+++ b/project-xml-data-interchange/earlyfinish-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EarlyFinish element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EarlyFinish Element

--- a/project-xml-data-interchange/earlystart-element.md
+++ b/project-xml-data-interchange/earlystart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EarlyStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EarlyStart Element

--- a/project-xml-data-interchange/earnedvaluemethod-element.md
+++ b/project-xml-data-interchange/earnedvaluemethod-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EarnedValueMethod element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EarnedValueMethod Element

--- a/project-xml-data-interchange/editableactualcosts-element.md
+++ b/project-xml-data-interchange/editableactualcosts-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EditableActualCosts element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EditableActualCosts Element

--- a/project-xml-data-interchange/effortdriven-element.md
+++ b/project-xml-data-interchange/effortdriven-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EffortDriven element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EffortDriven Element

--- a/project-xml-data-interchange/elemtype-element.md
+++ b/project-xml-data-interchange/elemtype-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ElemType Element

--- a/project-xml-data-interchange/emailaddress-element.md
+++ b/project-xml-data-interchange/emailaddress-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EmailAddress element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EmailAddress Element

--- a/project-xml-data-interchange/enteredbyoccurrences-element.md
+++ b/project-xml-data-interchange/enteredbyoccurrences-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EnteredByOccurrences Element

--- a/project-xml-data-interchange/enterprise-element.md
+++ b/project-xml-data-interchange/enterprise-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Enterprise element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Enterprise Element

--- a/project-xml-data-interchange/enterpriseextendedattribute-element.md
+++ b/project-xml-data-interchange/enterpriseextendedattribute-element.md
@@ -2,6 +2,7 @@
 title: EnterpriseExtendedAttribute Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EnterpriseExtendedAttribute Element

--- a/project-xml-data-interchange/enterpriseoutlinecodealias-element.md
+++ b/project-xml-data-interchange/enterpriseoutlinecodealias-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EnterpriseOutlineCodeAlias element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EnterpriseOutlineCodeAlias Element

--- a/project-xml-data-interchange/estimated-element.md
+++ b/project-xml-data-interchange/estimated-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Estimated element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Estimated Element

--- a/project-xml-data-interchange/estimatedduration-element.md
+++ b/project-xml-data-interchange/estimatedduration-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - EstimatedDuration element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # EstimatedDuration Element

--- a/project-xml-data-interchange/exception-element.md
+++ b/project-xml-data-interchange/exception-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Exception Element

--- a/project-xml-data-interchange/exceptions-element.md
+++ b/project-xml-data-interchange/exceptions-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Exceptions Element

--- a/project-xml-data-interchange/extendedattribute-element.md
+++ b/project-xml-data-interchange/extendedattribute-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExtendedAttribute Element

--- a/project-xml-data-interchange/extendedattribute-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/extendedattribute-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExtendedAttribute Elements and XML Structure

--- a/project-xml-data-interchange/extendedattributes-element.md
+++ b/project-xml-data-interchange/extendedattributes-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ExtendedAttributes element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExtendedAttributes Element

--- a/project-xml-data-interchange/extendedcreationdate-element.md
+++ b/project-xml-data-interchange/extendedcreationdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ExtendedCreationDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExtendedCreationDate Element

--- a/project-xml-data-interchange/externalfilename-element.md
+++ b/project-xml-data-interchange/externalfilename-element.md
@@ -2,6 +2,7 @@
 title: ExternalFileName Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExternalFileName Element

--- a/project-xml-data-interchange/externalfilereference-element.md
+++ b/project-xml-data-interchange/externalfilereference-element.md
@@ -2,6 +2,7 @@
 title: ExternalFileReference Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExternalFileReference Element

--- a/project-xml-data-interchange/externalsource-element.md
+++ b/project-xml-data-interchange/externalsource-element.md
@@ -2,6 +2,7 @@
 title: ExternalSource Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExternalSource Element

--- a/project-xml-data-interchange/externaltask-element.md
+++ b/project-xml-data-interchange/externaltask-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ExternalTask element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExternalTask Element

--- a/project-xml-data-interchange/externaltaskproject-element.md
+++ b/project-xml-data-interchange/externaltaskproject-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ExternalTaskProject element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ExternalTaskProject Element

--- a/project-xml-data-interchange/f404000-f4040c8-elements.md
+++ b/project-xml-data-interchange/f404000-f4040c8-elements.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - f404000 - f4040c8 elements
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # f404000 - f4040c8 Elements

--- a/project-xml-data-interchange/f408000-f417fff-elements.md
+++ b/project-xml-data-interchange/f408000-f417fff-elements.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - f408000 - f417fff elements
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # f408000 - f417fff Elements

--- a/project-xml-data-interchange/fieldguid-element.md
+++ b/project-xml-data-interchange/fieldguid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FieldGUID Element

--- a/project-xml-data-interchange/fieldid-element.md
+++ b/project-xml-data-interchange/fieldid-element.md
@@ -2,6 +2,7 @@
 title: FieldID Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FieldID Element

--- a/project-xml-data-interchange/fieldidinhex-element.md
+++ b/project-xml-data-interchange/fieldidinhex-element.md
@@ -2,6 +2,7 @@
 title: FieldIDInHex Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FieldIDInHex Element

--- a/project-xml-data-interchange/fieldname-element.md
+++ b/project-xml-data-interchange/fieldname-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FieldName element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FieldName Element

--- a/project-xml-data-interchange/fieldvalueguid-element.md
+++ b/project-xml-data-interchange/fieldvalueguid-element.md
@@ -2,6 +2,7 @@
 title: FieldValueGUID Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FieldValueGUID Element

--- a/project-xml-data-interchange/filter-element.md
+++ b/project-xml-data-interchange/filter-element.md
@@ -2,6 +2,7 @@
 title: Filter Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Filter Element

--- a/project-xml-data-interchange/filters-element.md
+++ b/project-xml-data-interchange/filters-element.md
@@ -2,6 +2,7 @@
 title: Filters Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Filters Element

--- a/project-xml-data-interchange/finish-element.md
+++ b/project-xml-data-interchange/finish-element.md
@@ -2,6 +2,7 @@
 title: Finish Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Finish Element

--- a/project-xml-data-interchange/finishdate-element.md
+++ b/project-xml-data-interchange/finishdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FinishDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FinishDate Element

--- a/project-xml-data-interchange/finishvariance-element.md
+++ b/project-xml-data-interchange/finishvariance-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FinishVariance element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FinishVariance Element

--- a/project-xml-data-interchange/fiscalyearstart-element.md
+++ b/project-xml-data-interchange/fiscalyearstart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FiscalYearStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FiscalYearStart Element

--- a/project-xml-data-interchange/fixedcost-element-baseline.md
+++ b/project-xml-data-interchange/fixedcost-element-baseline.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FixedCost Element (Baseline)

--- a/project-xml-data-interchange/fixedcostaccrual-element.md
+++ b/project-xml-data-interchange/fixedcostaccrual-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FixedCostAccrual element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FixedCostAccrual Element

--- a/project-xml-data-interchange/fixedmaterial-element.md
+++ b/project-xml-data-interchange/fixedmaterial-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FixedMaterial element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FixedMaterial Element

--- a/project-xml-data-interchange/formula-element.md
+++ b/project-xml-data-interchange/formula-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Formula Element

--- a/project-xml-data-interchange/freeslack-element.md
+++ b/project-xml-data-interchange/freeslack-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FreeSlack Element

--- a/project-xml-data-interchange/fromdate-element-calendar.md
+++ b/project-xml-data-interchange/fromdate-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FromDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FromDate Element (Calendar)

--- a/project-xml-data-interchange/fromtime-element-calendar.md
+++ b/project-xml-data-interchange/fromtime-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FromTime element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FromTime Element (Calendar)

--- a/project-xml-data-interchange/fystartdate-element.md
+++ b/project-xml-data-interchange/fystartdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - FYStartDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # FYStartDate Element

--- a/project-xml-data-interchange/generatecodes-element.md
+++ b/project-xml-data-interchange/generatecodes-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # GenerateCodes Element

--- a/project-xml-data-interchange/group-element.md
+++ b/project-xml-data-interchange/group-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Group element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Group Element

--- a/project-xml-data-interchange/groupgroups-element.md
+++ b/project-xml-data-interchange/groupgroups-element.md
@@ -2,6 +2,7 @@
 title: Group Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Group Element

--- a/project-xml-data-interchange/groups-element.md
+++ b/project-xml-data-interchange/groups-element.md
@@ -2,6 +2,7 @@
 title: Groups Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Groups Element

--- a/project-xml-data-interchange/guid-element-multiple-parents.md
+++ b/project-xml-data-interchange/guid-element-multiple-parents.md
@@ -2,6 +2,7 @@
 title: Guid Element (Multiple Parents)
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Guid Element (Multiple Parents)

--- a/project-xml-data-interchange/hasfixedrateunits-element.md
+++ b/project-xml-data-interchange/hasfixedrateunits-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - HasFixedRateUnits element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # HasFixedRateUnits Element

--- a/project-xml-data-interchange/hidebar-element.md
+++ b/project-xml-data-interchange/hidebar-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - HideBar element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # HideBar Element

--- a/project-xml-data-interchange/honorconstraints-element.md
+++ b/project-xml-data-interchange/honorconstraints-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - HonorConstraints element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # HonorConstraints Element

--- a/project-xml-data-interchange/how-to-use-xslt-transformations-with-project-xml-data-interchange-files.md
+++ b/project-xml-data-interchange/how-to-use-xslt-transformations-with-project-xml-data-interchange-files.md
@@ -19,6 +19,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # How to: Use XSLT Transformations with Project XML Data Interchange Files

--- a/project-xml-data-interchange/hyperlink-element.md
+++ b/project-xml-data-interchange/hyperlink-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Hyperlink Element

--- a/project-xml-data-interchange/hyperlinkaddress-element.md
+++ b/project-xml-data-interchange/hyperlinkaddress-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # HyperlinkAddress Element

--- a/project-xml-data-interchange/hyperlinksubaddress-element.md
+++ b/project-xml-data-interchange/hyperlinksubaddress-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # HyperlinkSubAddress Element

--- a/project-xml-data-interchange/id-element.md
+++ b/project-xml-data-interchange/id-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ID element
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ID Element

--- a/project-xml-data-interchange/ignoreresourcecalendar-element.md
+++ b/project-xml-data-interchange/ignoreresourcecalendar-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IgnoreResourceCalendar element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IgnoreResourceCalendar Element

--- a/project-xml-data-interchange/index.md
+++ b/project-xml-data-interchange/index.md
@@ -2,4 +2,5 @@
 redirect_url: 'project-xml-data-interchange-schema-reference'
 monikerRange: '>= project-client-2007 || project-client-odc'
 ms.date: 03/14/2018
+localization_priority: Normal
 ---

--- a/project-xml-data-interchange/initials-element.md
+++ b/project-xml-data-interchange/initials-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Initials element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Initials Element

--- a/project-xml-data-interchange/insertedprojectslikesummary-element.md
+++ b/project-xml-data-interchange/insertedprojectslikesummary-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - InsertedProjectsLikeSummary element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # InsertedProjectsLikeSummary Element

--- a/project-xml-data-interchange/interim-element.md
+++ b/project-xml-data-interchange/interim-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Interim element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Interim Element

--- a/project-xml-data-interchange/introduction-to-project-xml-data.md
+++ b/project-xml-data-interchange/introduction-to-project-xml-data.md
@@ -11,6 +11,7 @@ f1_keywords:
 - XML in Project
 - Project 2007, XML
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Priority
 ---
 
 # Introduction to Project XML Data

--- a/project-xml-data-interchange/isbasecalendar-element.md
+++ b/project-xml-data-interchange/isbasecalendar-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsBaseCalendar element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsBaseCalendar Element

--- a/project-xml-data-interchange/isbudget-element.md
+++ b/project-xml-data-interchange/isbudget-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsBudget Element

--- a/project-xml-data-interchange/iscostresource-element.md
+++ b/project-xml-data-interchange/iscostresource-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsCostResource Element

--- a/project-xml-data-interchange/iscustomized-element.md
+++ b/project-xml-data-interchange/iscustomized-element.md
@@ -2,6 +2,7 @@
 title: IsCustomized Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsCustomized Element

--- a/project-xml-data-interchange/isenterprise-element.md
+++ b/project-xml-data-interchange/isenterprise-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsEnterprise element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsEnterprise Element

--- a/project-xml-data-interchange/isgeneric-element.md
+++ b/project-xml-data-interchange/isgeneric-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsGeneric element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsGeneric Element

--- a/project-xml-data-interchange/isinactive-element.md
+++ b/project-xml-data-interchange/isinactive-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsInactive element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsInactive Element

--- a/project-xml-data-interchange/isnull-element.md
+++ b/project-xml-data-interchange/isnull-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsNull element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsNull Element

--- a/project-xml-data-interchange/ispublished-element.md
+++ b/project-xml-data-interchange/ispublished-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsPublished Element

--- a/project-xml-data-interchange/issubproject-element.md
+++ b/project-xml-data-interchange/issubproject-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsSubproject Element

--- a/project-xml-data-interchange/issubprojectreadonly-element.md
+++ b/project-xml-data-interchange/issubprojectreadonly-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - IsSubprojectReadOnly element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # IsSubprojectReadOnly Element

--- a/project-xml-data-interchange/lagformat-element.md
+++ b/project-xml-data-interchange/lagformat-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LagFormat element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LagFormat Element

--- a/project-xml-data-interchange/lastsaved-element.md
+++ b/project-xml-data-interchange/lastsaved-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LastSaved element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LastSaved Element

--- a/project-xml-data-interchange/latefinish-element.md
+++ b/project-xml-data-interchange/latefinish-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LateFinish element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LateFinish Element

--- a/project-xml-data-interchange/latestart-element.md
+++ b/project-xml-data-interchange/latestart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LateStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LateStart Element

--- a/project-xml-data-interchange/leafonly-element.md
+++ b/project-xml-data-interchange/leafonly-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LeafOnly element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LeafOnly Element

--- a/project-xml-data-interchange/length-element.md
+++ b/project-xml-data-interchange/length-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Length element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Length Element

--- a/project-xml-data-interchange/level-element.md
+++ b/project-xml-data-interchange/level-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Level element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Level Element

--- a/project-xml-data-interchange/levelassignments-element.md
+++ b/project-xml-data-interchange/levelassignments-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LevelAssignments element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LevelAssignments Element

--- a/project-xml-data-interchange/levelingcansplit-element.md
+++ b/project-xml-data-interchange/levelingcansplit-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LevelingCanSplit element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LevelingCanSplit Element

--- a/project-xml-data-interchange/levelingdelay-element.md
+++ b/project-xml-data-interchange/levelingdelay-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LevelingDelay Element

--- a/project-xml-data-interchange/levelingdelayformat-element.md
+++ b/project-xml-data-interchange/levelingdelayformat-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LevelingDelayFormat Element

--- a/project-xml-data-interchange/linkedfields-element.md
+++ b/project-xml-data-interchange/linkedfields-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LinkedFields element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LinkedFields Element

--- a/project-xml-data-interchange/linklag-element.md
+++ b/project-xml-data-interchange/linklag-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - LinkLag element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # LinkLag Element

--- a/project-xml-data-interchange/ltuid-element.md
+++ b/project-xml-data-interchange/ltuid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Ltuid Element

--- a/project-xml-data-interchange/manager-element.md
+++ b/project-xml-data-interchange/manager-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Manager element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Manager Element

--- a/project-xml-data-interchange/map-element.md
+++ b/project-xml-data-interchange/map-element.md
@@ -2,6 +2,7 @@
 title: Map Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Map Element

--- a/project-xml-data-interchange/maps-element.md
+++ b/project-xml-data-interchange/maps-element.md
@@ -2,6 +2,7 @@
 title: Maps Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Maps Element

--- a/project-xml-data-interchange/mask-element.md
+++ b/project-xml-data-interchange/mask-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Mask element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Mask Element

--- a/project-xml-data-interchange/masks-element.md
+++ b/project-xml-data-interchange/masks-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Masks element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Masks Element

--- a/project-xml-data-interchange/materiallabel-element.md
+++ b/project-xml-data-interchange/materiallabel-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MaterialLabel element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MaterialLabel Element

--- a/project-xml-data-interchange/maxmultivalues-element.md
+++ b/project-xml-data-interchange/maxmultivalues-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MaxMultiValues Element

--- a/project-xml-data-interchange/maxunits-element.md
+++ b/project-xml-data-interchange/maxunits-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MaxUnits element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MaxUnits Element

--- a/project-xml-data-interchange/microsoftprojectserverurl-element.md
+++ b/project-xml-data-interchange/microsoftprojectserverurl-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MicrosoftProjectServerURL element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MicrosoftProjectServerURL Element

--- a/project-xml-data-interchange/milestone-element.md
+++ b/project-xml-data-interchange/milestone-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Milestone element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Milestone Element

--- a/project-xml-data-interchange/minutesperday-element.md
+++ b/project-xml-data-interchange/minutesperday-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MinutesPerDay element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MinutesPerDay Element

--- a/project-xml-data-interchange/minutesperweek-element.md
+++ b/project-xml-data-interchange/minutesperweek-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MinutesPerWeek element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MinutesPerWeek Element

--- a/project-xml-data-interchange/month-element.md
+++ b/project-xml-data-interchange/month-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Month Element

--- a/project-xml-data-interchange/monthday-element.md
+++ b/project-xml-data-interchange/monthday-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MonthDay Element

--- a/project-xml-data-interchange/monthitem-element.md
+++ b/project-xml-data-interchange/monthitem-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MonthItem Element

--- a/project-xml-data-interchange/monthposition-element.md
+++ b/project-xml-data-interchange/monthposition-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MonthPosition Element

--- a/project-xml-data-interchange/movecompletedendsback-element.md
+++ b/project-xml-data-interchange/movecompletedendsback-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MoveCompletedEndsBack element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MoveCompletedEndsBack Element

--- a/project-xml-data-interchange/movecompletedendsforward-element.md
+++ b/project-xml-data-interchange/movecompletedendsforward-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MoveCompletedEndsForward element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MoveCompletedEndsForward Element

--- a/project-xml-data-interchange/moveremainingstartsback-element.md
+++ b/project-xml-data-interchange/moveremainingstartsback-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MoveRemainingStartsBack element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MoveRemainingStartsBack Element

--- a/project-xml-data-interchange/moveremainingstartsforward-element.md
+++ b/project-xml-data-interchange/moveremainingstartsforward-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MoveRemainingStartsForward element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MoveRemainingStartsForward Element

--- a/project-xml-data-interchange/multiplecriticalpaths-element.md
+++ b/project-xml-data-interchange/multiplecriticalpaths-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - MultipleCriticalPaths element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # MultipleCriticalPaths Element

--- a/project-xml-data-interchange/name-element.md
+++ b/project-xml-data-interchange/name-element.md
@@ -2,6 +2,7 @@
 title: Name Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Name Element

--- a/project-xml-data-interchange/new-xml-elements.md
+++ b/project-xml-data-interchange/new-xml-elements.md
@@ -12,6 +12,7 @@ f1_keywords:
 - Project 2007, XML
 - Project XML schema changes
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # New XML Elements

--- a/project-xml-data-interchange/newtaskseffortdriven-element.md
+++ b/project-xml-data-interchange/newtaskseffortdriven-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - NewTasksEffortDriven element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # NewTasksEffortDriven Element

--- a/project-xml-data-interchange/newtasksestimated-element.md
+++ b/project-xml-data-interchange/newtasksestimated-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - NewTasksEstimated element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # NewTasksEstimated Element

--- a/project-xml-data-interchange/newtaskstartdate-element.md
+++ b/project-xml-data-interchange/newtaskstartdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - NewTaskStartDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # NewTaskStartDate Element

--- a/project-xml-data-interchange/nextavailableboardstatuscolumnorderingid-element.md
+++ b/project-xml-data-interchange/nextavailableboardstatuscolumnorderingid-element.md
@@ -2,6 +2,7 @@
 title: NextAvailableBoardStatusColumnOrderingID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # NextAvailableBoardStatusColumnOrderingID Element

--- a/project-xml-data-interchange/nextavailablesprintorderingid-element.md
+++ b/project-xml-data-interchange/nextavailablesprintorderingid-element.md
@@ -2,6 +2,7 @@
 title: NextAvailableSprintOrderingID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # NextAvailableSprintOrderingID Element

--- a/project-xml-data-interchange/notecontainsobjects-element.md
+++ b/project-xml-data-interchange/notecontainsobjects-element.md
@@ -2,6 +2,7 @@
 title: NoteContainsObjects Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # NoteContainsObjects Element

--- a/project-xml-data-interchange/notes-element.md
+++ b/project-xml-data-interchange/notes-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Notes element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Notes Element

--- a/project-xml-data-interchange/ntaccount-element.md
+++ b/project-xml-data-interchange/ntaccount-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - NTAccount element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # NTAccount Element

--- a/project-xml-data-interchange/number-element.md
+++ b/project-xml-data-interchange/number-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Number element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Number Element

--- a/project-xml-data-interchange/occurrences-element.md
+++ b/project-xml-data-interchange/occurrences-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Occurrences Element

--- a/project-xml-data-interchange/onlytablevaluesallowed-element.md
+++ b/project-xml-data-interchange/onlytablevaluesallowed-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OnlyTableValuesAllowed element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OnlyTableValuesAllowed Element

--- a/project-xml-data-interchange/outlinecode-element.md
+++ b/project-xml-data-interchange/outlinecode-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OutlineCode Element

--- a/project-xml-data-interchange/outlinecode-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/outlinecode-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OutlineCode Elements and XML Structure

--- a/project-xml-data-interchange/outlinecodes-element.md
+++ b/project-xml-data-interchange/outlinecodes-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OutlineCodes element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OutlineCodes Element

--- a/project-xml-data-interchange/outlinelevel-element.md
+++ b/project-xml-data-interchange/outlinelevel-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OutlineLevel element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OutlineLevel Element

--- a/project-xml-data-interchange/outlinenumber-element.md
+++ b/project-xml-data-interchange/outlinenumber-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OutlineNumber element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OutlineNumber Element

--- a/project-xml-data-interchange/overallocated-element.md
+++ b/project-xml-data-interchange/overallocated-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OverAllocated element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OverAllocated Element

--- a/project-xml-data-interchange/overtimecost-element.md
+++ b/project-xml-data-interchange/overtimecost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OvertimeCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OvertimeCost Element

--- a/project-xml-data-interchange/overtimerate-element.md
+++ b/project-xml-data-interchange/overtimerate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OvertimeRate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OvertimeRate Element

--- a/project-xml-data-interchange/overtimerateformat-element.md
+++ b/project-xml-data-interchange/overtimerateformat-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OvertimeRateFormat element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OvertimeRateFormat Element

--- a/project-xml-data-interchange/overtimework-element.md
+++ b/project-xml-data-interchange/overtimework-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - OvertimeWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # OvertimeWork Element

--- a/project-xml-data-interchange/parentvalueid-element.md
+++ b/project-xml-data-interchange/parentvalueid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ParentValueID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ParentValueID Element

--- a/project-xml-data-interchange/peakunits-element.md
+++ b/project-xml-data-interchange/peakunits-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PeakUnits element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PeakUnits Element

--- a/project-xml-data-interchange/percentcomplete-element.md
+++ b/project-xml-data-interchange/percentcomplete-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PercentComplete element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PercentComplete Element

--- a/project-xml-data-interchange/percentworkcomplete-element.md
+++ b/project-xml-data-interchange/percentworkcomplete-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PercentWorkComplete element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PercentWorkComplete Element

--- a/project-xml-data-interchange/period-element.md
+++ b/project-xml-data-interchange/period-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Period Element

--- a/project-xml-data-interchange/phonetic-element.md
+++ b/project-xml-data-interchange/phonetic-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Phonetic element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Phonetic Element

--- a/project-xml-data-interchange/phoneticalias-element.md
+++ b/project-xml-data-interchange/phoneticalias-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PhoneticAlias element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PhoneticAlias Element

--- a/project-xml-data-interchange/phonetics-element.md
+++ b/project-xml-data-interchange/phonetics-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Phonetics element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Phonetics Element

--- a/project-xml-data-interchange/physicalpercentcomplete-element.md
+++ b/project-xml-data-interchange/physicalpercentcomplete-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PhysicalPercentComplete element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PhysicalPercentComplete Element

--- a/project-xml-data-interchange/predecessorlink-element.md
+++ b/project-xml-data-interchange/predecessorlink-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PredecessorLink element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PredecessorLink Element

--- a/project-xml-data-interchange/predecessoruid-element.md
+++ b/project-xml-data-interchange/predecessoruid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PredecessorUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PredecessorUID Element

--- a/project-xml-data-interchange/prefix-element.md
+++ b/project-xml-data-interchange/prefix-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Prefix element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Prefix Element

--- a/project-xml-data-interchange/preleveledfinish-element.md
+++ b/project-xml-data-interchange/preleveledfinish-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PreLeveledFinish element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PreLeveledFinish Element

--- a/project-xml-data-interchange/preleveledstart-element.md
+++ b/project-xml-data-interchange/preleveledstart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - PreLeveledStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # PreLeveledStart Element

--- a/project-xml-data-interchange/priority-element.md
+++ b/project-xml-data-interchange/priority-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Priority element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Priority Element

--- a/project-xml-data-interchange/project-data-interchange-elements.md
+++ b/project-xml-data-interchange/project-data-interchange-elements.md
@@ -12,6 +12,7 @@ f1_keywords:
 - Project XML elements
 - Project 2007 XML
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Project Data Interchange Elements

--- a/project-xml-data-interchange/project-element.md
+++ b/project-xml-data-interchange/project-element.md
@@ -2,6 +2,7 @@
 title: Project Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Project Element

--- a/project-xml-data-interchange/project-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/project-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Project Elements and XML Structure

--- a/project-xml-data-interchange/project-xml-data-interchange-schema-reference.md
+++ b/project-xml-data-interchange/project-xml-data-interchange-schema-reference.md
@@ -11,6 +11,7 @@ f1_keywords:
 - XML in Project
 - Project 2007, XML
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Project XML Data Interchange Schema Reference

--- a/project-xml-data-interchange/projectexternallyedited-element.md
+++ b/project-xml-data-interchange/projectexternallyedited-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ProjectExternallyEdited element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ProjectExternallyEdited Element

--- a/project-xml-data-interchange/rate-element.md
+++ b/project-xml-data-interchange/rate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Rate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Rate Element

--- a/project-xml-data-interchange/rates-element.md
+++ b/project-xml-data-interchange/rates-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Rates element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Rates Element

--- a/project-xml-data-interchange/ratesfrom-element.md
+++ b/project-xml-data-interchange/ratesfrom-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RatesFrom element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RatesFrom Element

--- a/project-xml-data-interchange/ratesto-element.md
+++ b/project-xml-data-interchange/ratesto-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RatesTo element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RatesTo Element

--- a/project-xml-data-interchange/ratetable-element.md
+++ b/project-xml-data-interchange/ratetable-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RateTable element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RateTable Element

--- a/project-xml-data-interchange/recurring-element.md
+++ b/project-xml-data-interchange/recurring-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Recurring element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Recurring Element

--- a/project-xml-data-interchange/regularwork-element.md
+++ b/project-xml-data-interchange/regularwork-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RegularWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RegularWork Element

--- a/project-xml-data-interchange/remainingcost-element.md
+++ b/project-xml-data-interchange/remainingcost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemainingCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemainingCost Element

--- a/project-xml-data-interchange/remainingduration-element.md
+++ b/project-xml-data-interchange/remainingduration-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemainingDuration element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemainingDuration Element

--- a/project-xml-data-interchange/remainingovertimecost-element.md
+++ b/project-xml-data-interchange/remainingovertimecost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemainingOvertimeCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemainingOvertimeCost Element

--- a/project-xml-data-interchange/remainingovertimework-element.md
+++ b/project-xml-data-interchange/remainingovertimework-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemainingOvertimeWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemainingOvertimeWork Element

--- a/project-xml-data-interchange/remainingwork-element.md
+++ b/project-xml-data-interchange/remainingwork-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemainingWork element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemainingWork Element

--- a/project-xml-data-interchange/removefileproperties-element.md
+++ b/project-xml-data-interchange/removefileproperties-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RemoveFileProperties element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RemoveFileProperties Element

--- a/project-xml-data-interchange/report-element.md
+++ b/project-xml-data-interchange/report-element.md
@@ -2,6 +2,7 @@
 title: Report Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Report Element

--- a/project-xml-data-interchange/reports-element.md
+++ b/project-xml-data-interchange/reports-element.md
@@ -2,6 +2,7 @@
 title: Reports Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Reports Element

--- a/project-xml-data-interchange/resource-element.md
+++ b/project-xml-data-interchange/resource-element.md
@@ -2,6 +2,7 @@
 title: Resource Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Resource Element

--- a/project-xml-data-interchange/resource-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/resource-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Resource Elements and XML Structure

--- a/project-xml-data-interchange/resources-element.md
+++ b/project-xml-data-interchange/resources-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Resources element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Resources Element

--- a/project-xml-data-interchange/resourcesubstitutionenabled-element.md
+++ b/project-xml-data-interchange/resourcesubstitutionenabled-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ResourceSubstitutionEnabled element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ResourceSubstitutionEnabled Element

--- a/project-xml-data-interchange/resourceuid-element.md
+++ b/project-xml-data-interchange/resourceuid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ResourceUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ResourceUID Element

--- a/project-xml-data-interchange/responsepending-element.md
+++ b/project-xml-data-interchange/responsepending-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ResponsePending element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ResponsePending Element

--- a/project-xml-data-interchange/restrictvalues-element.md
+++ b/project-xml-data-interchange/restrictvalues-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RestrictValues element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RestrictValues Element

--- a/project-xml-data-interchange/resume-element.md
+++ b/project-xml-data-interchange/resume-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Resume element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Resume Element

--- a/project-xml-data-interchange/resumevalid-element.md
+++ b/project-xml-data-interchange/resumevalid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ResumeValid element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ResumeValid Element

--- a/project-xml-data-interchange/revision-element.md
+++ b/project-xml-data-interchange/revision-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Revision element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Revision Element

--- a/project-xml-data-interchange/rollup-element.md
+++ b/project-xml-data-interchange/rollup-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Rollup element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Rollup Element

--- a/project-xml-data-interchange/rolluptype-element.md
+++ b/project-xml-data-interchange/rolluptype-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - RollupType element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RollupType Element

--- a/project-xml-data-interchange/rownumber-element.md
+++ b/project-xml-data-interchange/rownumber-element.md
@@ -2,6 +2,7 @@
 title: RowNumber Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RowNumber Element

--- a/project-xml-data-interchange/rownumbers-element.md
+++ b/project-xml-data-interchange/rownumbers-element.md
@@ -2,6 +2,7 @@
 title: RowNumbers Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # RowNumbers Element

--- a/project-xml-data-interchange/saveversion-element.md
+++ b/project-xml-data-interchange/saveversion-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SaveVersion Element

--- a/project-xml-data-interchange/saving-and-opening-projects-in-xml-format.md
+++ b/project-xml-data-interchange/saving-and-opening-projects-in-xml-format.md
@@ -11,6 +11,7 @@ f1_keywords:
 - XML files
 - Project XML files
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Priority
 ---
 
 # Saving and Opening Projects in XML Format

--- a/project-xml-data-interchange/schedulefromstart-element.md
+++ b/project-xml-data-interchange/schedulefromstart-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ScheduleFromStart element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ScheduleFromStart Element

--- a/project-xml-data-interchange/secondarypid-element.md
+++ b/project-xml-data-interchange/secondarypid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SecondaryPID Element

--- a/project-xml-data-interchange/separator-element.md
+++ b/project-xml-data-interchange/separator-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Separator element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Separator Element

--- a/project-xml-data-interchange/sink-element.md
+++ b/project-xml-data-interchange/sink-element.md
@@ -2,6 +2,7 @@
 title: Sink Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Sink Element

--- a/project-xml-data-interchange/source-element.md
+++ b/project-xml-data-interchange/source-element.md
@@ -2,6 +2,7 @@
 title: Source Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Source Element

--- a/project-xml-data-interchange/splitsinprogresstasks-element.md
+++ b/project-xml-data-interchange/splitsinprogresstasks-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - SplitsInProgressTasks element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SplitsInProgressTasks Element

--- a/project-xml-data-interchange/spreadactualcost-element.md
+++ b/project-xml-data-interchange/spreadactualcost-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - SpreadActualCost element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SpreadActualCost Element

--- a/project-xml-data-interchange/spreadpercentcomplete-element.md
+++ b/project-xml-data-interchange/spreadpercentcomplete-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - SpreadPercentComplete element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SpreadPercentComplete Element

--- a/project-xml-data-interchange/sprint-element.md
+++ b/project-xml-data-interchange/sprint-element.md
@@ -2,6 +2,7 @@
 title: Sprint Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # Sprint Element

--- a/project-xml-data-interchange/sprintcolumnorderingid-element.md
+++ b/project-xml-data-interchange/sprintcolumnorderingid-element.md
@@ -2,6 +2,7 @@
 title: SprintColumnOrderingID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # SprintColumnOrderingID Element

--- a/project-xml-data-interchange/sprintcreationthroughdate-element.md
+++ b/project-xml-data-interchange/sprintcreationthroughdate-element.md
@@ -2,6 +2,7 @@
 title: SprintCreationThroughDate Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # SprintCreationThroughDate Element

--- a/project-xml-data-interchange/sprintlength-element.md
+++ b/project-xml-data-interchange/sprintlength-element.md
@@ -2,6 +2,7 @@
 title: SprintLength Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # SprintLength Element

--- a/project-xml-data-interchange/sprints-element.md
+++ b/project-xml-data-interchange/sprints-element.md
@@ -2,6 +2,7 @@
 title: Sprints Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # Sprints Element

--- a/project-xml-data-interchange/sprintuid-element.md
+++ b/project-xml-data-interchange/sprintuid-element.md
@@ -2,6 +2,7 @@
 title: SprintUID Element
 ms.date: 03/14/2018
 monikerRange: 'project-client-odc'
+localization_priority: Normal
 ---
 
 # SprintUID Element

--- a/project-xml-data-interchange/standardrate-element.md
+++ b/project-xml-data-interchange/standardrate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - StandardRate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StandardRate Element

--- a/project-xml-data-interchange/standardrateformat-element.md
+++ b/project-xml-data-interchange/standardrateformat-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - StandardRateFormat element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StandardRateFormat Element

--- a/project-xml-data-interchange/start-element.md
+++ b/project-xml-data-interchange/start-element.md
@@ -2,6 +2,7 @@
 title: Start Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Start Element

--- a/project-xml-data-interchange/startdate-element.md
+++ b/project-xml-data-interchange/startdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - StartDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StartDate Element

--- a/project-xml-data-interchange/startvariance-element.md
+++ b/project-xml-data-interchange/startvariance-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - StartVariance element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StartVariance Element

--- a/project-xml-data-interchange/statusdate-element.md
+++ b/project-xml-data-interchange/statusdate-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - StatusDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StatusDate Element

--- a/project-xml-data-interchange/statusmanager-element.md
+++ b/project-xml-data-interchange/statusmanager-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # StatusManager Element

--- a/project-xml-data-interchange/stop-element.md
+++ b/project-xml-data-interchange/stop-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Stop element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Stop Element

--- a/project-xml-data-interchange/subject-element.md
+++ b/project-xml-data-interchange/subject-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Subject element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Subject Element

--- a/project-xml-data-interchange/subprojectname-element.md
+++ b/project-xml-data-interchange/subprojectname-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SubprojectName Element

--- a/project-xml-data-interchange/summary-element.md
+++ b/project-xml-data-interchange/summary-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Summary element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Summary Element

--- a/project-xml-data-interchange/sv-element.md
+++ b/project-xml-data-interchange/sv-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - SV element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # SV Element

--- a/project-xml-data-interchange/table-element.md
+++ b/project-xml-data-interchange/table-element.md
@@ -2,6 +2,7 @@
 title: Table Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Table Element

--- a/project-xml-data-interchange/tables-element.md
+++ b/project-xml-data-interchange/tables-element.md
@@ -2,6 +2,7 @@
 title: Tables Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Tables Element

--- a/project-xml-data-interchange/task-element.md
+++ b/project-xml-data-interchange/task-element.md
@@ -2,6 +2,7 @@
 title: Task Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Task Element

--- a/project-xml-data-interchange/task-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/task-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Task Elements and XML Structure

--- a/project-xml-data-interchange/tasks-element.md
+++ b/project-xml-data-interchange/tasks-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Tasks element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Tasks Element

--- a/project-xml-data-interchange/taskuid-element.md
+++ b/project-xml-data-interchange/taskuid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - TaskUID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TaskUID Element

--- a/project-xml-data-interchange/taskupdatesresource-element.md
+++ b/project-xml-data-interchange/taskupdatesresource-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - TaskUpdatesResource element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TaskUpdatesResource Element

--- a/project-xml-data-interchange/timeperiod-element-calendar.md
+++ b/project-xml-data-interchange/timeperiod-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - TimePeriod element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TimePeriod Element (Calendar)

--- a/project-xml-data-interchange/timephaseddata-element.md
+++ b/project-xml-data-interchange/timephaseddata-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TimephasedData Element

--- a/project-xml-data-interchange/timephaseddatatype-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/timephaseddatatype-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TimephasedDataType Elements and XML Structure

--- a/project-xml-data-interchange/title-element-project.md
+++ b/project-xml-data-interchange/title-element-project.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Title element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Title Element (Project)

--- a/project-xml-data-interchange/todate-element-calendar.md
+++ b/project-xml-data-interchange/todate-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ToDate element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ToDate Element (Calendar)

--- a/project-xml-data-interchange/totalslack-element.md
+++ b/project-xml-data-interchange/totalslack-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # TotalSlack Element

--- a/project-xml-data-interchange/totime-element-calendar.md
+++ b/project-xml-data-interchange/totime-element-calendar.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ToTime element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ToTime Element (Calendar)

--- a/project-xml-data-interchange/type-element-multiple-parents.md
+++ b/project-xml-data-interchange/type-element-multiple-parents.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Type element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Type Element (Multiple Parents)

--- a/project-xml-data-interchange/uid-element.md
+++ b/project-xml-data-interchange/uid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - UID element
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # UID Element

--- a/project-xml-data-interchange/unit-element.md
+++ b/project-xml-data-interchange/unit-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Unit element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Unit Element

--- a/project-xml-data-interchange/units-element.md
+++ b/project-xml-data-interchange/units-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Units element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Units Element

--- a/project-xml-data-interchange/updateneeded-element.md
+++ b/project-xml-data-interchange/updateneeded-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - UpdateNeeded element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # UpdateNeeded Element

--- a/project-xml-data-interchange/userdef-element.md
+++ b/project-xml-data-interchange/userdef-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # UserDef Element

--- a/project-xml-data-interchange/vac-element.md
+++ b/project-xml-data-interchange/vac-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - VAC element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # VAC Element

--- a/project-xml-data-interchange/value-element.md
+++ b/project-xml-data-interchange/value-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Value element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Value Element

--- a/project-xml-data-interchange/valueguid-element.md
+++ b/project-xml-data-interchange/valueguid-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ValueGUID Element

--- a/project-xml-data-interchange/valueid-element.md
+++ b/project-xml-data-interchange/valueid-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ValueID element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ValueID Element

--- a/project-xml-data-interchange/valuelist-element.md
+++ b/project-xml-data-interchange/valuelist-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ValueList element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ValueList Element

--- a/project-xml-data-interchange/valuelistsortorder-element.md
+++ b/project-xml-data-interchange/valuelistsortorder-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - ValuelistSortOrder element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # ValuelistSortOrder Element

--- a/project-xml-data-interchange/values-element.md
+++ b/project-xml-data-interchange/values-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - Values element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Values Element

--- a/project-xml-data-interchange/vbaproject-element.md
+++ b/project-xml-data-interchange/vbaproject-element.md
@@ -2,6 +2,7 @@
 title: VBAProject Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # VBAProject Element

--- a/project-xml-data-interchange/vbaprojects-element.md
+++ b/project-xml-data-interchange/vbaprojects-element.md
@@ -2,6 +2,7 @@
 title: VBAProjects Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # VBAProjects Element

--- a/project-xml-data-interchange/verifyuniquecodes-element.md
+++ b/project-xml-data-interchange/verifyuniquecodes-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - VerifyUniqueCodes element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # VerifyUniqueCodes Element

--- a/project-xml-data-interchange/view-element.md
+++ b/project-xml-data-interchange/view-element.md
@@ -2,6 +2,7 @@
 title: View Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # View Element

--- a/project-xml-data-interchange/views-element.md
+++ b/project-xml-data-interchange/views-element.md
@@ -2,6 +2,7 @@
 title: Views Element
 ms.date: 03/14/2018
 monikerRange: '>= project-client-2010 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Views Element

--- a/project-xml-data-interchange/wbs-element.md
+++ b/project-xml-data-interchange/wbs-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WBS element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WBS Element

--- a/project-xml-data-interchange/wbslevel-element.md
+++ b/project-xml-data-interchange/wbslevel-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WBSLevel element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WBSLevel Element

--- a/project-xml-data-interchange/wbsmask-element.md
+++ b/project-xml-data-interchange/wbsmask-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WBSMask Element

--- a/project-xml-data-interchange/wbsmask-elements-and-xml-structure.md
+++ b/project-xml-data-interchange/wbsmask-elements-and-xml-structure.md
@@ -15,6 +15,7 @@ f1_keywords:
 - Project 2007 XML
 - Project XML structure
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WBSMask Elements and XML Structure

--- a/project-xml-data-interchange/wbsmasks-element.md
+++ b/project-xml-data-interchange/wbsmasks-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WBSMasks Element

--- a/project-xml-data-interchange/weekday-element.md
+++ b/project-xml-data-interchange/weekday-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WeekDay Element

--- a/project-xml-data-interchange/weekdays-element.md
+++ b/project-xml-data-interchange/weekdays-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WeekDays Element

--- a/project-xml-data-interchange/weekstartday-element.md
+++ b/project-xml-data-interchange/weekstartday-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WeekStartDay element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WeekStartDay Element

--- a/project-xml-data-interchange/work-element.md
+++ b/project-xml-data-interchange/work-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Work Element

--- a/project-xml-data-interchange/workcontour-element.md
+++ b/project-xml-data-interchange/workcontour-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WorkContour element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkContour Element

--- a/project-xml-data-interchange/workformat-element.md
+++ b/project-xml-data-interchange/workformat-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WorkFormat element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkFormat Element

--- a/project-xml-data-interchange/workgroup-element.md
+++ b/project-xml-data-interchange/workgroup-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WorkGroup element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkGroup Element

--- a/project-xml-data-interchange/working-with-project-xml-data-interchange-files.md
+++ b/project-xml-data-interchange/working-with-project-xml-data-interchange-files.md
@@ -11,6 +11,7 @@ f1_keywords:
 - XML schema [Project 2007]
 - Project 2007 XML
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # Working with Project XML Data Interchange Files

--- a/project-xml-data-interchange/workingtime-element-calendar.md
+++ b/project-xml-data-interchange/workingtime-element-calendar.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkingTime Element (Calendar)

--- a/project-xml-data-interchange/workingtimes-element-calendar.md
+++ b/project-xml-data-interchange/workingtimes-element-calendar.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkingTimes Element (Calendar)

--- a/project-xml-data-interchange/workvariance-element.md
+++ b/project-xml-data-interchange/workvariance-element.md
@@ -9,6 +9,7 @@ mtps_version: v=office.12
 f1_keywords:
 - WorkVariance element
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkVariance Element

--- a/project-xml-data-interchange/workweek-element.md
+++ b/project-xml-data-interchange/workweek-element.md
@@ -12,6 +12,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkWeek Element

--- a/project-xml-data-interchange/workweeks-element.md
+++ b/project-xml-data-interchange/workweeks-element.md
@@ -11,6 +11,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # WorkWeeks Element

--- a/project-xml-data-interchange/xml-schema-for-the-assignments-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-assignments-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the Assignments Element

--- a/project-xml-data-interchange/xml-schema-for-the-calendars-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-calendars-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the Calendars Element

--- a/project-xml-data-interchange/xml-schema-for-the-extendedattributes-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-extendedattributes-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the ExtendedAttributes Element

--- a/project-xml-data-interchange/xml-schema-for-the-outlinecodes-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-outlinecodes-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the OutlineCodes Element

--- a/project-xml-data-interchange/xml-schema-for-the-project-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-project-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the Project Element

--- a/project-xml-data-interchange/xml-schema-for-the-resources-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-resources-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the Resources Element

--- a/project-xml-data-interchange/xml-schema-for-the-tasks-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-tasks-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the Tasks Element

--- a/project-xml-data-interchange/xml-schema-for-the-timephaseddatatype-complex-type.md
+++ b/project-xml-data-interchange/xml-schema-for-the-timephaseddatatype-complex-type.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the TimephasedDataType Complex Type

--- a/project-xml-data-interchange/xml-schema-for-the-wbsmasks-element.md
+++ b/project-xml-data-interchange/xml-schema-for-the-wbsmasks-element.md
@@ -16,6 +16,7 @@ f1_keywords:
 dev_langs:
 - xml
 monikerRange: '>= project-client-2007 || project-client-odc'
+localization_priority: Normal
 ---
 
 # XML Schema for the WBSMasks Element


### PR DESCRIPTION
Submitted by Office Intl team to apply metadata localization_priority to source markdown topics.

Contact GSXCON-Tech if you have questions.
